### PR TITLE
[UOD-1291] improve dkafka resilience

### DIFF
--- a/adapt.go
+++ b/adapt.go
@@ -14,9 +14,10 @@ type Adapter interface {
 }
 
 type BlockStep struct {
-	blk    *pbcodec.Block
-	step   pbbstream.ForkStep
-	cursor string
+	blk            *pbcodec.Block
+	step           pbbstream.ForkStep
+	cursor         string
+	previousCursor string
 }
 
 func (bs BlockStep) time() time.Time {
@@ -37,6 +38,10 @@ func (bs BlockStep) timeHeader() kafka.Header {
 
 func (bs BlockStep) opaqueCursor() string {
 	return bs.cursor
+}
+
+func (bs BlockStep) previousOpaqueCursor() string {
+	return bs.previousCursor
 }
 
 type CdCAdapter struct {

--- a/brequest.go
+++ b/brequest.go
@@ -10,6 +10,34 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
+type position struct {
+	cursor               *forkable.Cursor
+	opaqueCursor         string
+	previousCursor       *forkable.Cursor
+	previousOpaqueCursor string
+}
+
+func (p position) gt(that position) bool {
+	if p.previousCursor != nil && that.previousCursor == nil {
+		return true
+	}
+	if p.previousCursor == nil && that.previousCursor != nil {
+		return false
+	}
+	if p.previousCursor != nil && that.previousCursor != nil {
+		return that.previousCursor.Block.Num() < p.previousCursor.Block.Num()
+	}
+	return that.cursor.Block.Num() < p.cursor.Block.Num()
+}
+
+func (p position) opaque() string {
+	if len(p.previousOpaqueCursor) > 0 {
+		return p.previousOpaqueCursor
+	} else {
+		return p.opaqueCursor
+	}
+}
+
 func NewRequest(filter string, startBlock int64, stopBlock uint64, cursor string, irreversibleOnly bool) *pbbstream.BlocksRequestV2 {
 	req := pbbstream.BlocksRequestV2{
 		IncludeFilterExpr: filter,
@@ -24,25 +52,29 @@ func NewRequest(filter string, startBlock int64, stopBlock uint64, cursor string
 	return &req
 }
 
-func findCursor(headers []kafka.Header) (cursor string) {
+func findPosition(headers []kafka.Header) (position position) {
 	for _, header := range headers {
 		zlog.Debug("check heard", zap.String("key", header.Key), zap.ByteString("value", header.Value))
 		if header.Key == CursorHeaderKey {
 			zlog.Debug("find cursor", zap.String("key", header.Key), zap.ByteString("value", header.Value))
-			return string(header.Value)
+			position.opaqueCursor = string(header.Value)
+		}
+		if header.Key == PreviousCursorHeaderKey {
+			zlog.Debug("find cursor", zap.String("key", header.Key), zap.ByteString("value", header.Value))
+			position.previousOpaqueCursor = string(header.Value)
 		}
 	}
 	return
 }
 
 // LoadCursor load the latest cursor stored in the given topic and update the request accordingly
-func LoadCursor(config kafka.ConfigMap, topic string) (opaqueCursor string, err error) {
+func LoadCursor(config kafka.ConfigMap, topic string) (string, error) {
 	config["group.id"] = "cursor-loader"
 	config["enable.auto.commit"] = false
 
 	consumer, err := kafka.NewConsumer(&config)
 	if err != nil {
-		return opaqueCursor, fmt.Errorf("creating consumer to load cursor: %w", err)
+		return "", fmt.Errorf("creating consumer to load cursor: %w", err)
 	}
 
 	defer func() {
@@ -55,39 +87,38 @@ func LoadCursor(config kafka.ConfigMap, topic string) (opaqueCursor string, err 
 
 	md, err := consumer.GetMetadata(&topic, false, 500)
 	if err != nil {
-		return opaqueCursor, fmt.Errorf("getting metadata for loading cursor from topic: %s,error: %w", topic, err)
+		return "", fmt.Errorf("getting metadata for loading cursor from topic: %s,error: %w", topic, err)
 	}
 	parts := md.Topics[topic].Partitions
 	if len(parts) == 0 {
 		zlog.Info("topic does not exist no cursor to load", zap.String("topic", topic))
-		return opaqueCursor, nil
+		return "", nil
 	}
-	var cursor *forkable.Cursor
+	var latest position = position{}
 	for _, partition := range parts {
-		c, oc, err := getHeadCursorFromPartion(consumer, topic, partition)
+		position, err := getHeadCursorFromPartition(consumer, topic, partition)
 		if err != nil {
-			return opaqueCursor, err
+			return "", err
 		}
-		if c == nil {
+		if position.cursor == nil { // happen if strange messages in the topic or old dkafka messages
 			continue
 		}
-		if cursor == nil || cursor.Block.Num() < c.Block.Num() {
-			zlog.Debug("found max cursor", zap.Int32("partition", partition.ID), zap.Uint64("block_num", c.Block.Num()))
-			cursor = c
-			opaqueCursor = oc
+		if position.gt(latest) {
+			zlog.Debug("found max cursor", zap.Int32("partition", partition.ID), zap.Uint64("block_num", position.cursor.Block.Num()))
+			latest = position
 		}
 	}
-	return opaqueCursor, nil
+	return latest.opaque(), nil
 }
 
-func getHeadCursorFromPartion(consumer *kafka.Consumer, topic string, partition kafka.PartitionMetadata) (cursor *forkable.Cursor, opaqueCursor string, err error) {
+func getHeadCursorFromPartition(consumer *kafka.Consumer, topic string, partition kafka.PartitionMetadata) (position position, err error) {
 	low, high, err := consumer.QueryWatermarkOffsets(topic, partition.ID, 500)
 	if err != nil {
-		return cursor, opaqueCursor, fmt.Errorf("getting low/high watermarque for topic: %s, partition: %d, error: %w", topic, partition.ID, err)
+		return position, fmt.Errorf("getting low/high watermark for topic: %s, partition: %d, error: %w", topic, partition.ID, err)
 	}
 
 	for i := kafka.Offset(high) - 1; i >= kafka.Offset(low); i-- {
-		zlog.Debug("retrive cursor header from kafka message", zap.String("topic", topic), zap.Int32("partition", partition.ID), zap.Int64("offset", int64(i)))
+		zlog.Debug("retrieve cursor header from kafka message", zap.String("topic", topic), zap.Int32("partition", partition.ID), zap.Int64("offset", int64(i)))
 		err = consumer.Assign([]kafka.TopicPartition{
 			{
 				Topic:     &topic,
@@ -102,16 +133,22 @@ func getHeadCursorFromPartion(consumer *kafka.Consumer, topic string, partition 
 		ev := consumer.Poll(1000)
 		switch event := ev.(type) {
 		case kafka.Error:
-			return cursor, opaqueCursor, event
+			return position, event
 		case *kafka.Message:
 			zlog.Debug("look for cursor header", zap.Int("nb_headers", len(event.Headers)))
-			opaqueCursor = findCursor(event.Headers)
-			if opaqueCursor == "" {
+			position = findPosition(event.Headers)
+			if position.opaqueCursor == "" {
+				// should not happen but if the producer in this topic are not only dkafka instances...
+				// or if the message where produce by a very old version of dkafka
+				// which was not using cursor headers
 				zlog.Debug("no cursor found in headers")
 				continue
 			}
 			zlog.Debug("read opaque cursor")
-			cursor, err = forkable.CursorFromOpaque(opaqueCursor)
+			if position.cursor, err = forkable.CursorFromOpaque(position.opaqueCursor); err != nil {
+				return
+			}
+			position.previousCursor, _ = forkable.CursorFromOpaque(position.previousOpaqueCursor)
 			return
 		default:
 			zlog.Debug("un-handled kafka.Event type", zap.Any("event", event))

--- a/brequest_test.go
+++ b/brequest_test.go
@@ -1,0 +1,168 @@
+package dkafka
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/confluentinc/confluent-kafka-go/kafka"
+	"github.com/streamingfast/bstream/forkable"
+)
+
+const opaqueCursor1 = "6QXTyGxzkcfhhxXa-8kWF6WzLpc-DFJmUQLgLBFEj4vz9XfM1Z6jBWNxaRuDxqDwjka-TA79jN2bHXspoJZRvYTrlbg25SM-RC8lmt_oqeXncKH3MV8Ydbw3C-KJY9nRUzXTaw_9c7AK4NDiP_rRbxA7Zc90LGLg2z9Y84dUJqIQ6ndnw22rJc_S0P-SoIdE_LF2RO2jliimBzF8eBtTOs-BZ_Kbuzp2MA=="
+
+var cursor1 = cursorFromOpaque(opaqueCursor1)
+
+const opaqueCursor2 = "hsDNMretWsuoLJ-5SF69saWzLpc-DFJmUQLgLBFFj4vz9XfM1Z6iBmRxbEmBwvqm2kS6Swup2dvLEHl8o8IEtNPpx-xkvyE9RHopxtru-7Xre6b7PFgbd-lhXu2JZNnRUzXTaw_9c7AK4NDiP_rRbxA7Zc90LGLg2z9Y84dUJqIQ6ndnw22rJc_S0P-SoIdE_LF2RO2jliimBzF8eBtTOs-BZ_Kbuzp2MA=="
+
+var cursor2 = cursorFromOpaque(opaqueCursor2)
+
+func cursorFromOpaque(in string) (cursor *forkable.Cursor) {
+	cursor, _ = forkable.CursorFromOpaque(in)
+	return
+}
+
+func Test_findPosition(t *testing.T) {
+	type args struct {
+		headers []kafka.Header
+	}
+	tests := []struct {
+		name         string
+		args         args
+		wantPosition position
+	}{
+		{
+			name:         "empty",
+			args:         args{[]kafka.Header{}},
+			wantPosition: position{},
+		},
+		{
+			name: "only cursor",
+			args: args{[]kafka.Header{{
+				Key:   CursorHeaderKey,
+				Value: []byte(opaqueCursor1),
+			},
+			},
+			},
+			wantPosition: position{
+				opaqueCursor: opaqueCursor1,
+			},
+		},
+		{
+			name: "full cursors",
+			args: args{[]kafka.Header{{
+				Key:   CursorHeaderKey,
+				Value: []byte(opaqueCursor1),
+			},
+				{
+					Key:   PreviousCursorHeaderKey,
+					Value: []byte(opaqueCursor2),
+				},
+				{
+					Key:   CursorHeaderKey,
+					Value: []byte(opaqueCursor1),
+				},
+			},
+			},
+			wantPosition: position{
+				opaqueCursor:         opaqueCursor1,
+				previousOpaqueCursor: opaqueCursor2,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if gotPosition := findPosition(tt.args.headers); !reflect.DeepEqual(gotPosition, tt.wantPosition) {
+				t.Errorf("findPosition() = %v, want %v", gotPosition, tt.wantPosition)
+			}
+		})
+	}
+}
+
+func Test_position_gt(t *testing.T) {
+	tests := []struct {
+		name string
+		this position
+		that position
+		want bool
+	}{
+		{
+			name: "no previous this greater than that",
+			this: position{
+				cursor: cursor1,
+			},
+			that: position{
+				cursor: cursor2,
+			},
+			want: true,
+		},
+		{
+			name: "no previous this lower than that",
+			this: position{
+				cursor: cursor2,
+			},
+			that: position{
+				cursor: cursor1,
+			},
+			want: false,
+		},
+		{
+			name: "no previous this equals to that",
+			this: position{
+				cursor: cursor1,
+			},
+			that: position{
+				cursor: cursor1,
+			},
+			want: false,
+		},
+		{
+			name: "this with previous and not that",
+			this: position{
+				cursor:         cursor1,
+				previousCursor: cursor2,
+			},
+			that: position{
+				cursor: cursor2,
+			},
+			want: true,
+		},
+		{
+			name: "this without previous but that",
+			this: position{
+				cursor: cursor1,
+			},
+			that: position{
+				cursor:         cursor2,
+				previousCursor: cursor2,
+			},
+			want: false,
+		},
+		{
+			name: "this and that with previous with this gt that",
+			this: position{
+				previousCursor: cursor1,
+			},
+			that: position{
+				previousCursor: cursor2,
+			},
+			want: true,
+		},
+		{
+			name: "this and that with previous with that gt this",
+			this: position{
+				previousCursor: cursor2,
+			},
+			that: position{
+				previousCursor: cursor1,
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.this.gt(tt.that); got != tt.want {
+				t.Errorf("position.gt() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add the previous block cursor to the current block events to allow restart from it.
It add the price of some duplicated events but with the garanty of no data loose.