### PR TITLE
[UOD-1299] add wildcard support on cdc actions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ CDC_TABLES_ACCOUNT ?= 'eosio.nft.ft'
 CDC_TABLES_TABLE_NAMES ?= '*:s+k'
 CDC_TABLES_START_BLOCK ?= 89495000
 ## CDC ACTIONS
-CDC_ACTIONS_EXPRESSION ?= '{"create":"transaction_id", "issue":"data.issue.to"}'
+CDC_ACTIONS_EXPRESSION ?= '{"issue":"data.issue.to", "*": "first_auth_actor"}'
 CDC_ACTIONS_START_BLOCK ?= 70837000
 CDC_ACTIONS_ACCOUNT ?= 'eosio.nft.ft'
 ##

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Using the compression level and type is not enough. The max message size is veri
   * `scheduled`: (filter property only) bool, if true, the action was scheduled (delayed or deferred)
   * `trx_action_count`: (filter property only) number of actions within that transaction
   * `db_ops`: list of database operations executed by this action
+  * `first_auth_actor`: a shortcut to the first actor name whose has signed the transaction
 
 * examples:
   * to generate two events per action, one with 'account' as the key, one with the 'receiver' as the key (duplicates are removed automatically)

--- a/adapter_test.go
+++ b/adapter_test.go
@@ -283,7 +283,7 @@ func Benchmark_adapter_adapt(b *testing.B) {
 				headers: default_headers,
 			}
 		case CDC_ACTION_ADAPTER:
-			actionKeyExpressions, err := createCdcKeyExpressions(`{"create":"transaction_id"}`, ActionDeclarations)
+			actionKeyExpressions, err := createCdcKeyExpressions(`{"create":"transaction_id"}`)
 			if err != nil {
 				b.Fatalf("createCdcKeyExpressions() error: %v", err)
 				return
@@ -316,7 +316,7 @@ func Benchmark_adapter_adapt(b *testing.B) {
 				headers: default_headers,
 			}
 		case CDC_ACTION_ADAPTER_AVRO:
-			actionKeyExpressions, err := createCdcKeyExpressions(`{"create":"transaction_id"}`, ActionDeclarations)
+			actionKeyExpressions, err := createCdcKeyExpressions(`{"create":"transaction_id"}`)
 			if err != nil {
 				b.Fatalf("createCdcKeyExpressions() error: %v", err)
 				return

--- a/cel.go
+++ b/cel.go
@@ -186,6 +186,7 @@ var ActionDeclarations = cel.Declarations(
 
 	decls.NewVar("data", decls.NewMapType(decls.String, decls.Any)),
 	decls.NewVar("auth", decls.NewListType(decls.String)),
+	decls.NewVar("first_auth_actor", decls.NewListType(decls.String)),
 )
 
 func NewActionActivation(stepName string, transaction *pbcodec.TransactionTrace, trace *pbcodec.ActionTrace) (interpreter.Activation, error) {
@@ -221,6 +222,9 @@ func NewActionActivation(stepName string, transaction *pbcodec.TransactionTrace,
 			}
 
 			return jsonStringToMap(jsonData)
+		},
+		"first_auth_actor": func() interface{} {
+			return trace.Action.Authorization[0].Actor
 		},
 	}
 	return interpreter.NewActivation(activationMap)

--- a/gen.go
+++ b/gen.go
@@ -71,6 +71,8 @@ func indexDbOps(gc GenContext) []*IndexedEntry[*pbcodec.DBOp] {
 
 type TableKeyExtractorFinder func(string) (ExtractKey, bool)
 
+type ActionKeyExtractorFinder func(string) (cel.Program, bool)
+
 type TableGenerator struct {
 	getExtractKey TableKeyExtractorFinder
 	abiCodec      ABICodec
@@ -156,7 +158,7 @@ func (tg TableGenerator) doApply(gc GenContext) ([]generation, error) {
 }
 
 type ActionGenerator2 struct {
-	keyExtractors map[string]cel.Program
+	keyExtractors ActionKeyExtractorFinder
 	abiCodec      ABICodec
 }
 
@@ -199,7 +201,7 @@ func (ag ActionGenerator2) Apply(gc GenContext) ([]Generation2, error) {
 
 func (ag ActionGenerator2) doApply(gc GenContext) ([]generation, error) {
 	actionName := gc.actionTrace.Action.Name
-	extractor, found := ag.keyExtractors[actionName]
+	extractor, found := ag.keyExtractors(actionName)
 	if !found {
 		return nil, nil
 	}


### PR DESCRIPTION
Now you can use `*` when you want to construct action key extraction expression