### PR TITLE
[UOD-2318] Add support for notifications on cdc tables

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -54,5 +54,6 @@
           ]
         }
       },
-      "terminal.integrated.defaultProfile.linux": "BashWithStartup"
+      "terminal.integrated.defaultProfile.linux": "BashWithStartup",
+      "makefile.configureOnOpen": false
 }

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ CDC_START_BLOCK ?= 135283642
 CDC_ACCOUNT ?= eosio.nft.ft
 
 CDC_TABLES_START_BLOCK ?= $(CDC_START_BLOCK)
+CDC_TABLES_STOP_BLOCK := $(CDC_START_BLOCK)
 CDC_TABLES_ACCOUNT ?= $(CDC_ACCOUNT)
 CDC_TABLES_TABLE_NAMES ?= *:s+k
 ## CDC ACTIONS
@@ -149,6 +150,8 @@ cdc-tables: ## CDC stream on tables
 		--kafka-compression-level=$(COMPRESSION_LEVEL) \
 		--kafka-message-max-bytes=$(MESSAGE_MAX_SIZE) \
 		--start-block-num=$(CDC_TABLES_START_BLOCK) \
+		--stop-block-num=$(CDC_TABLES_STOP_BLOCK) \
+		--batch-mode=$(BATCH_MODE) \
 		--codec=$(CODEC) \
 		--table-name='$(CDC_TABLES_TABLE_NAMES)' '$(CDC_TABLES_ACCOUNT)'
 

--- a/README.md
+++ b/README.md
@@ -284,6 +284,9 @@ $ make test-avro-generation
 ```
 If there is no error then your schema should be valid for a production integration ;)
 
+#### improvement 
+* Use testify: https://github.com/stretchr/testify
+
 ### Run
 There is several launcher in the `Makefile` and multiple variables can be overridden. 
 Please have look to the `Makefile` for more details.

--- a/abidecoder_test.go
+++ b/abidecoder_test.go
@@ -63,6 +63,7 @@ func TestParseABIFileSpec(t *testing.T) {
 
 func TestLoadABIFile(t *testing.T) {
 	type args struct {
+		account string
 		abiFile string
 	}
 	tests := []struct {
@@ -74,6 +75,7 @@ func TestLoadABIFile(t *testing.T) {
 		{
 			name: "default",
 			args: args{
+				account: "eosio.nft.ft",
 				abiFile: "testdata/eosio.nft.ft.abi",
 			},
 			wantABIBlockNum: uint32(0),
@@ -82,6 +84,7 @@ func TestLoadABIFile(t *testing.T) {
 		{
 			name: "with-block-number",
 			args: args{
+				account: "eosio.nft.ft",
 				abiFile: "testdata/eosio.nft.ft.abi:1",
 			},
 			wantABIBlockNum: uint32(1),
@@ -97,7 +100,7 @@ func TestLoadABIFile(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := LoadABIFile(tt.args.abiFile)
+			got, err := LoadABIFile(tt.args.account, tt.args.abiFile)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("LoadABIFile() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/action/filter.go
+++ b/action/filter.go
@@ -1,0 +1,7 @@
+package action
+
+import "fmt"
+
+func Filter(account string) string {
+	return fmt.Sprintf("(account==\"%s\" && receiver==\"%s\")", account, account)
+}

--- a/action/filter_test.go
+++ b/action/filter_test.go
@@ -1,0 +1,36 @@
+package action
+
+import "testing"
+
+func TestFilter(t *testing.T) {
+	type args struct {
+		account string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "eosio.token",
+			args: args{
+				account: "eosio.token",
+			},
+			want: `(account=="eosio.token" && receiver=="eosio.token")`,
+		},
+		{
+			name: "eosio.eba",
+			args: args{
+				account: "eosio.eba",
+			},
+			want: `(account=="eosio.eba" && receiver=="eosio.eba")`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Filter(tt.args.account); got != tt.want {
+				t.Errorf("Filter() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/adapt_test.go
+++ b/adapt_test.go
@@ -141,34 +141,38 @@ func TestCdCAdapter_Adapt_pb(t *testing.T) {
 		table      string
 		nbMessages int
 	}{
-		// {
-		// 	"accounts",
-		// 	"testdata/block-49608395.pb.json",
-		// 	"testdata/eosio.token.abi",
-		// 	"accounts",
-		// 	2,
-		// },
-		// {
-		// 	"nft-factory",
-		// 	"testdata/block-50705256.pb.json",
-		// 	"testdata/eosio.nft.ft.abi",
-		// 	"factory.a",
-		// 	1,
-		// },
-		// {
-		// 	"nft-factory-b",
-		// 	"testdata/block-135283216.pb.json",
-		// 	"testdata/eosio.nft.ft-4.0.6-snapshot.abi",
-		// 	"factory.b",
-		// 	1,
-		// },
-		// {
-		// 	"eosio.oracle",
-		// 	"testdata/block-43922498.pb.json",
-		// 	"testdata/eosio.oracle.abi",
-		// 	"*",
-		// 	4,
-		// },
+		{
+			"accounts",
+			"testdata/block-49608395.pb.json",
+			"testdata/eosio.token.abi",
+			map[string]string{"eosio.token": "testdata/eosio.token.abi"},
+			"accounts",
+			2,
+		},
+		{
+			"nft-factory",
+			"testdata/block-50705256.pb.json",
+			"testdata/eosio.nft.ft.abi",
+			map[string]string{"eosio.nft.ft": "testdata/eosio.nft.ft.abi"},
+			"factory.a",
+			1,
+		},
+		{
+			"nft-factory-b",
+			"testdata/block-135283216.pb.json",
+			"testdata/eosio.nft.ft-4.0.6-snapshot.abi",
+			map[string]string{"eosio.nft.ft": "testdata/eosio.nft.ft-4.0.6-snapshot.abi"},
+			"factory.b",
+			1,
+		},
+		{
+			"eosio.oracle",
+			"testdata/block-43922498.pb.json",
+			"testdata/eosio.oracle.abi",
+			map[string]string{"eosio.oracle": "testdata/eosio.oracle.abi"},
+			"*",
+			4,
+		},
 		{
 			"eosio.token-chained-table",
 			"testdata/block-224785515.pb.json",

--- a/adapter_test.go
+++ b/adapter_test.go
@@ -321,7 +321,7 @@ func Benchmark_adapter_adapt(b *testing.B) {
 				abiCodecCli: abiDecoder.abiCodecCli,
 				context:     abiDecoder.context,
 			}, msg.getTableSchema, srclient.CreateMockSchemaRegistryClient("mock://bench-adapter"), msg.Account, "mock://bench-adapter")
-			abiCodec.GetCodec("factory.a", 0)
+			abiCodec.GetCodec(CodecId{"eosio.nft.ft", "factory.a"}, 0)
 			finder, _ := buildTableKeyExtractorFinder([]string{"factory.a:k"})
 			adp = &CdCAdapter{
 				topic:     "test.topic",
@@ -353,7 +353,7 @@ func Benchmark_adapter_adapt(b *testing.B) {
 				abiCodecCli: abiDecoder.abiCodecCli,
 				context:     abiDecoder.context,
 			}, msg.getActionSchema, srclient.CreateMockSchemaRegistryClient("mock://bench-adapter"), msg.Account, "mock://bench-adapter")
-			abiCodec.GetCodec("create", 0)
+			abiCodec.GetCodec(CodecId{"eosio.nft.ft", "create"}, 0)
 			adp = &CdCAdapter{
 				topic:     "test.topic",
 				saveBlock: saveBlockNoop,

--- a/app.go
+++ b/app.go
@@ -841,7 +841,11 @@ func (msg MessageSchemaGenerator) newNamedSchemaGenOptions(kind string, name str
 
 func (msg MessageSchemaGenerator) namespace(kind string, account string) string {
 	accountLowerNameSpace := strcase.ToDelimited(account, '.')
-	return fmt.Sprintf("%s.%s.%s.v%d", msg.Namespace, accountLowerNameSpace, kind, msg.MajorVersion)
+	if msg.Namespace == "" {
+		return fmt.Sprintf("%s.%s.v%d", accountLowerNameSpace, kind, msg.MajorVersion)
+	} else {
+		return fmt.Sprintf("%s.%s.%s.v%d", msg.Namespace, accountLowerNameSpace, kind, msg.MajorVersion)
+	}
 }
 
 func schemaVersion(version string, majorVersion uint, abiBlockNumber uint32) string {

--- a/app_test.go
+++ b/app_test.go
@@ -221,3 +221,120 @@ func Test_createCdcKeyExpressions(t *testing.T) {
 		})
 	}
 }
+
+func Test_addExecutedFilter(t *testing.T) {
+	type args struct {
+		filter   string
+		executed bool
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "executed with filter",
+			args: args{
+				filter:   "filter",
+				executed: true,
+			},
+			want: "executed && filter",
+		},
+		{
+			name: "executed without filter",
+			args: args{
+				filter:   "",
+				executed: true,
+			},
+			want: "executed",
+		},
+		{
+			name: "not executed without filter",
+			args: args{
+				filter:   "",
+				executed: false,
+			},
+			want: "",
+		},
+		{
+			name: "not executed with filter",
+			args: args{
+				filter:   "filter",
+				executed: false,
+			},
+			want: "filter",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := addExecutedFilter(tt.args.filter, tt.args.executed); got != tt.want {
+				t.Errorf("addExecutedFilter() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMessageSchemaGenerator_namespace(t *testing.T) {
+	type fields struct {
+		Namespace    string
+		MajorVersion uint
+		Version      string
+		Account      string
+		Source       string
+	}
+	type args struct {
+		kind    string
+		account string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   string
+	}{
+		{
+			name: "actions",
+			fields: fields{
+				Namespace:    "io.dkafka.data",
+				MajorVersion: 1,
+				Version:      "1.2.3",
+				Account:      "eosio.token",
+				Source:       "test",
+			},
+			args: args{
+				kind:    ACTIONS_CDC_TYPE,
+				account: "ultra.rgrab",
+			},
+			want: "io.dkafka.data.ultra.rgrab.actions.v1",
+		},
+		{
+			name: "tables",
+			fields: fields{
+				Namespace:    "io.dkafka.data",
+				MajorVersion: 1,
+				Version:      "1.2.3",
+				Account:      "eosio.token",
+				Source:       "test",
+			},
+			args: args{
+				kind:    TABLES_CDC_TYPE,
+				account: "ultra.rgrab",
+			},
+			want: "io.dkafka.data.ultra.rgrab.tables.v1",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := MessageSchemaGenerator{
+				Namespace:    tt.fields.Namespace,
+				MajorVersion: tt.fields.MajorVersion,
+				Version:      tt.fields.Version,
+				Account:      tt.fields.Account,
+				Source:       tt.fields.Source,
+			}
+			if got := msg.namespace(tt.args.kind, tt.args.account); got != tt.want {
+				t.Errorf("MessageSchemaGenerator.namespace() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/app_test.go
+++ b/app_test.go
@@ -308,6 +308,21 @@ func TestMessageSchemaGenerator_namespace(t *testing.T) {
 			want: "io.dkafka.data.ultra.rgrab.actions.v1",
 		},
 		{
+			name: "empty-namespace-actions",
+			fields: fields{
+				Namespace:    "",
+				MajorVersion: 1,
+				Version:      "1.2.3",
+				Account:      "eosio.token",
+				Source:       "test",
+			},
+			args: args{
+				kind:    ACTIONS_CDC_TYPE,
+				account: "ultra.rgrab",
+			},
+			want: "ultra.rgrab.actions.v1",
+		},
+		{
 			name: "tables",
 			fields: fields{
 				Namespace:    "io.dkafka.data",
@@ -321,6 +336,21 @@ func TestMessageSchemaGenerator_namespace(t *testing.T) {
 				account: "ultra.rgrab",
 			},
 			want: "io.dkafka.data.ultra.rgrab.tables.v1",
+		},
+		{
+			name: "empty-namespace-tables",
+			fields: fields{
+				Namespace:    "",
+				MajorVersion: 1,
+				Version:      "1.2.3",
+				Account:      "eosio.token",
+				Source:       "test",
+			},
+			args: args{
+				kind:    TABLES_CDC_TYPE,
+				account: "ultra.rgrab",
+			},
+			want: "ultra.rgrab.tables.v1",
 		},
 	}
 	for _, tt := range tests {

--- a/avro.go
+++ b/avro.go
@@ -97,6 +97,13 @@ type RecordSchema struct {
 	Fields []FieldSchema `json:"fields"`
 }
 
+func (r *RecordSchema) AsCodecId() CodecId {
+	return CodecId{
+		Account: r.Namespace,
+		Name:    r.Name,
+	}
+}
+
 func newRecordS(name string, fields []FieldSchema) RecordSchema {
 	return newRecordFQN("", name, fields)
 }

--- a/cmd/dkafka/cdc.go
+++ b/cmd/dkafka/cdc.go
@@ -21,7 +21,7 @@ type GenOptions struct {
 	namespace string
 	version   string
 	outputDir string
-	abiSpec   dkafka.AbiSpec
+	abiSpec   *dkafka.ABI
 }
 
 var CdCCmd = &cobra.Command{
@@ -193,14 +193,14 @@ func generateAllAvroSchema(cmd *cobra.Command, args []string) {
 	}
 	zlog.Info("generate all schemas for:", zap.String("account", opts.abiSpec.Account))
 	zlog.Info("generate all Actions")
-	for _, action := range opts.abiSpec.Abi.Actions {
+	for _, action := range opts.abiSpec.Actions {
 		err = doGenActionAvroSchema(action.Name.String(), opts)
 		if err != nil {
 			zlog.Fatal("doGenActionAvroSchema()", zap.Error(err))
 		}
 	}
 	zlog.Info("generate all Tables")
-	for _, table := range opts.abiSpec.Abi.Tables {
+	for _, table := range opts.abiSpec.Tables {
 		err = doGenTableAvroSchema(string(table.Name), opts)
 		if err != nil {
 			zlog.Fatal("doGenTableAvroSchema()", zap.Error(err))
@@ -308,13 +308,9 @@ func genOptions(cmd *cobra.Command, args []string) (opts GenOptions, err error) 
 		zap.String("abi", abiString),
 	)
 
-	abi, err := dkafka.LoadABIFile(abiFile)
+	abiSpec, err := dkafka.LoadABIFile(account, abiFile)
 	if err != nil {
 		return
-	}
-	abiSpec := dkafka.AbiSpec{
-		Account: account,
-		Abi:     abi,
 	}
 
 	return GenOptions{

--- a/codec.go
+++ b/codec.go
@@ -85,7 +85,7 @@ type RegisteredSchema struct {
 	id      uint32
 	schema  string
 	version int
-	codec   *goavro.Codec
+	codec   *goavro.Codec `deep:"-"`
 }
 
 type KafkaAvroCodec struct {

--- a/go.mod
+++ b/go.mod
@@ -48,6 +48,7 @@ require (
 	github.com/census-instrumentation/opencensus-proto v0.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
+	github.com/go-test/deep v1.1.1 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/go-cmp v0.5.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -298,6 +298,8 @@ github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-test/deep v1.0.1/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
+github.com/go-test/deep v1.1.1 h1:0r/53hagsehfO4bzD2Pgr/+RgHqhmf+k1Bpse2cTu1U=
+github.com/go-test/deep v1.1.1/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gogo/protobuf v0.0.0-20180717141946-636bf0302bc9/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=

--- a/schema_test.go
+++ b/schema_test.go
@@ -163,13 +163,13 @@ func Test_resolveFieldTypeSchema(t *testing.T) {
 		),
 		{
 			name:    "unknown->error",
-			args:    args{"unknown", &ABI{&eos.ABI{}, 0}},
+			args:    args{"unknown", &ABI{ABI: &eos.ABI{}}},
 			want:    nil,
 			wantErr: true,
 		},
 		{
 			name: "struct->record",
-			args: args{"my_struct", &ABI{&eos.ABI{
+			args: args{"my_struct", &ABI{ABI: &eos.ABI{
 				Types: []eos.ABIType{{
 					NewTypeName: "int64_alias",
 					Type:        "int64",
@@ -188,7 +188,7 @@ func Test_resolveFieldTypeSchema(t *testing.T) {
 						},
 					},
 				}},
-			}, 42}},
+			}}},
 			want: RecordSchema{
 				Type: "record",
 				Name: "MyStruct",
@@ -207,7 +207,7 @@ func Test_resolveFieldTypeSchema(t *testing.T) {
 		},
 		{
 			name: "struct-inheritance",
-			args: args{"my_struct", &ABI{&eos.ABI{
+			args: args{"my_struct", &ABI{ABI: &eos.ABI{
 				Types: []eos.ABIType{{
 					NewTypeName: "int64_alias",
 					Type:        "int64",
@@ -218,7 +218,7 @@ func Test_resolveFieldTypeSchema(t *testing.T) {
 						Base: "",
 						Fields: []eos.FieldDef{
 							{
-								Name: "parentfieldA",
+								Name: "parentFieldA",
 								Type: "string",
 							},
 							{
@@ -241,13 +241,13 @@ func Test_resolveFieldTypeSchema(t *testing.T) {
 							},
 						},
 					}},
-			}, 42}},
+			}}},
 			want: RecordSchema{
 				Type: "record",
 				Name: "MyStruct",
 				Fields: []FieldSchema{
 					{
-						Name: "parentfieldA",
+						Name: "parentFieldA",
 						Type: TypedSchema{Type: "string", EosType: "string"},
 					},
 					{
@@ -268,7 +268,7 @@ func Test_resolveFieldTypeSchema(t *testing.T) {
 		},
 		{
 			name: "union-multiple-types-nullable",
-			args: args{"nullable_union_record", &ABI{&eos.ABI{
+			args: args{"nullable_union_record", &ABI{ABI: &eos.ABI{
 				Types: []eos.ABIType{{
 					NewTypeName: "nullable_union",
 					Type:        "variant_nullable_union",
@@ -288,7 +288,7 @@ func Test_resolveFieldTypeSchema(t *testing.T) {
 					Name:  "variant_nullable_union",
 					Types: []string{"string", "int8"},
 				}},
-			}, 42}},
+			}}},
 			want: RecordSchema{
 				Type: "record",
 				Name: "NullableUnionRecord",
@@ -304,7 +304,7 @@ func Test_resolveFieldTypeSchema(t *testing.T) {
 		},
 		{
 			name: "uber-variant",
-			args: args{"uber_variant", &ABI{&eos.ABI{
+			args: args{"uber_variant", &ABI{ABI: &eos.ABI{
 				Types: []eos.ABIType{
 					{
 						NewTypeName: "INT8_VEC",
@@ -374,7 +374,7 @@ func Test_resolveFieldTypeSchema(t *testing.T) {
 					Name:  HardcodedUberVariant,
 					Types: []string{"int8", "int16", "int32", "int64", "uint8", "uint16", "uint32", "uint64", "float32", "float64", "string", "boolean", "INT8_VEC", "INT16_VEC", "INT32_VEC", "INT64_VEC", "UINT8_VEC", "UINT16_VEC", "UINT32_VEC", "UINT64_VEC", "FLOAT32_VEC", "FLOAT64_VEC", "STRING_VEC", "BOOL_VEC"},
 				}},
-			}, 42}},
+			}}},
 			want: RecordSchema{
 				Type: "record",
 				Name: "UberVariant",
@@ -389,7 +389,7 @@ func Test_resolveFieldTypeSchema(t *testing.T) {
 		},
 		{
 			name: "union-multiple-types-nullable",
-			args: args{"nullable_union_record", &ABI{&eos.ABI{
+			args: args{"nullable_union_record", &ABI{ABI: &eos.ABI{
 				Types: []eos.ABIType{{
 					NewTypeName: "nullable_union",
 					Type:        "variant_nullable_union",
@@ -409,7 +409,7 @@ func Test_resolveFieldTypeSchema(t *testing.T) {
 					Name:  "variant_nullable_union",
 					Types: []string{"string", "int8"},
 				}},
-			}, 42}},
+			}}},
 			want: RecordSchema{
 				Type: "record",
 				Name: "NullableUnionRecord",
@@ -452,7 +452,7 @@ func Test_variantResolveFieldTypeSchema(t *testing.T) {
 	}{
 		{
 			name: "variant->union",
-			args: args{"regproducer2", &ABI{&eos.ABI{
+			args: args{"regproducer2", &ABI{ABI: &eos.ABI{
 				Types: []eos.ABIType{{
 					NewTypeName: "block_signing_authority",
 					Type:        "variant_block_signing_authority_v0",
@@ -481,7 +481,7 @@ func Test_variantResolveFieldTypeSchema(t *testing.T) {
 					Name:  "variant_block_signing_authority_v0",
 					Types: []string{"block_signing_authority_v0"},
 				}},
-			}, 42}},
+			}}},
 			want: RecordSchema{
 				Type: "record",
 				Name: "Regproducer2",
@@ -505,7 +505,7 @@ func Test_variantResolveFieldTypeSchema(t *testing.T) {
 		},
 		{
 			name: "variant->union multiple types",
-			args: args{"pair_string_key_value_store", &ABI{&eos.ABI{
+			args: args{"pair_string_key_value_store", &ABI{ABI: &eos.ABI{
 				Types: []eos.ABIType{
 					{
 						NewTypeName: "key_value_store",
@@ -531,7 +531,7 @@ func Test_variantResolveFieldTypeSchema(t *testing.T) {
 					Name:  "variant_int8_string",
 					Types: []string{"int8", "string"},
 				}},
-			}, 42}},
+			}}},
 			want: RecordSchema{
 				Type: "record",
 				Name: "PairStringKeyValueStore",
@@ -611,7 +611,7 @@ func TestActionToRecord(t *testing.T) {
 		{
 			"known_action",
 			args{
-				&ABI{&actionABI, 42},
+				&ABI{ABI: &actionABI},
 				"my_action",
 			},
 			RecordSchema{
@@ -633,7 +633,7 @@ func TestActionToRecord(t *testing.T) {
 		{
 			"unknown_action",
 			args{
-				&ABI{&actionABI, 42},
+				&ABI{ABI: &actionABI},
 				"unknown_action",
 			},
 			RecordSchema{},
@@ -694,7 +694,7 @@ func TestTableToRecord(t *testing.T) {
 		{
 			"known table",
 			args{
-				&ABI{&tableABI, 42},
+				&ABI{ABI: &tableABI},
 				"my.table",
 			},
 			RecordSchema{
@@ -716,7 +716,7 @@ func TestTableToRecord(t *testing.T) {
 		{
 			"unknown table",
 			args{
-				&ABI{&actionABI, 42},
+				&ABI{ABI: &actionABI},
 				"unknown.table",
 			},
 			RecordSchema{},

--- a/sender.go
+++ b/sender.go
@@ -79,7 +79,7 @@ func (s *FastKafkaSender) SaveCP(ctx context.Context, location location) error {
 		zap.Stringer("cursor_LIB", c.LIB),
 	)
 	checkpoint := newCheckpointMap(c, location.time())
-	codec, err := s.abiCodec.GetCodec(dkafkaCheckpoint, 0)
+	codec, err := s.abiCodec.GetCodec(CheckpointSchema.AsCodecId(), 0)
 	if err != nil {
 		return fmt.Errorf("SaveCP() fail to get codec for %s: %w", dkafkaCheckpoint, err)
 	}

--- a/table/filter.go
+++ b/table/filter.go
@@ -1,0 +1,7 @@
+package table
+
+import "fmt"
+
+func Filter(account string) string {
+	return fmt.Sprintf("account==\"%s\"", account)
+}

--- a/table/filter_test.go
+++ b/table/filter_test.go
@@ -1,0 +1,36 @@
+package table
+
+import "testing"
+
+func TestFilter(t *testing.T) {
+	type args struct {
+		account string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "eosio.token",
+			args: args{
+				account: "eosio.token",
+			},
+			want: `account=="eosio.token"`,
+		},
+		{
+			name: "eosio.eba",
+			args: args{
+				account: "eosio.eba",
+			},
+			want: `account=="eosio.eba"`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Filter(tt.args.account); got != tt.want {
+				t.Errorf("Filter() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/testdata/block-224785515.pb.json
+++ b/testdata/block-224785515.pb.json
@@ -1,0 +1,554 @@
+{
+    "id": "0d65f46b04f618e62675c2d693c6a3594dca5b5f946d802f7bc44c85e86ba3ea",
+    "number": 224785515,
+    "version": 1,
+    "header": {
+        "timestamp": "2025-01-10T15:46:01Z",
+        "producer": "eosioubisoft",
+        "previous": "0d65f46a6c53954c4e1d4ce4643eded6d524ca2b0b65904541a4edcf86caa7bb",
+        "transactionMroot": "3mz9nlYC7GD06Ukx5nfJaiSVfTH9TpW+W5HvjnMNu5o=",
+        "actionMroot": "Kc2tA6FOHRafTCzU4fGxR9Qh3gDyMjt28QrfTknqdRc=",
+        "scheduleVersion": 19
+    },
+    "producerSignature": "SIG_K1_K9GibDvLX25vouHemh1yRPuU3N7RTSHWzQ5N4gGPo9vjHmfB5QLSu4GURDbJPaX33bVprYSj7J8KEQ8MWptzYbsL6Eb1wJ",
+    "dposProposedIrreversibleBlocknum": 224785476,
+    "dposIrreversibleBlocknum": 224785428,
+    "blockrootMerkle": {
+        "nodeCount": 224785514,
+        "activeNodes": [
+            "ynbJN4fpsJ0seMlwAe3NMhKo91yO/6W+3VNjTkKFFJY=",
+            "01fYjzvKVTT2W5pqlQC2xLmVT/mwzLpF+B4IwQ8NHQg=",
+            "0fOQJT/s4ADHGPRC+j6JxDoYIe6gYwfSKsZzgr/XIvQ=",
+            "0O/fFsW1+o8VJ0MQrOpE/jhuQfLc/sVQp8Ot4IY1Rn0=",
+            "6P5+EZof9ovqhTZTzlRw3cNimgjrre30cOOxmI6fYQY=",
+            "kuuUSzw4+akyjW/YacPuPatgKW8hhFLZf0PelcGSmsM=",
+            "tmn/3IiF+4GTJrw95q/4CGilNzNpzoWORyJOEQLtwOo=",
+            "vOaPbooTZj7CecjLOheP6C/r9Fkt5k7NulJnMz/YAYs=",
+            "dVYFxNk8xKCZT0k8MhwBw+msWS0gOjoQA6hCIbxbdlE=",
+            "Pp7uXqBchRnfVCobYwVDQ8BFsTL+Ty83uVWYVe1j4qk=",
+            "20gooaM/sptXvZyE0qpVbzKO3K+FVnRiWw4fxozqDg0=",
+            "5hrRC88/TttFtrpgM5QZZWjIgPV5ud+v+Gjz8s1rTWA=",
+            "YzEwPxGINdf9rgIVVsUQXSkqbZX7rofPEv9UOxtp4Ws=",
+            "UyioFOAVc+G2ljacf97l9R2OMKFs1PyRAbbEJEP1xGY=",
+            "v2lXY2h8Gp4EFhhwCS/aHJ6HMHwrp4Tzv3DTBQR0b3I=",
+            "6wxQEY3S/RwkSVOtbgd70qou3/KL5/sKo/LzAAjVnno=",
+            "w80kyMKG7R//Y3c7vRdR9CXmALCjU3BNSY7VAiYmMRo="
+        ]
+    },
+    "producerToLastProduced": [
+        {
+            "name": "cryptolions1",
+            "lastBlockNumProduced": 224785512
+        },
+        {
+            "name": "eosioubisoft",
+            "lastBlockNumProduced": 224785515
+        },
+        {
+            "name": "eosnationftw",
+            "lastBlockNumProduced": 224785464
+        },
+        {
+            "name": "eosriobrazil",
+            "lastBlockNumProduced": 224785500
+        },
+        {
+            "name": "ivote4eosusa",
+            "lastBlockNumProduced": 224785476
+        },
+        {
+            "name": "uoseouldotio",
+            "lastBlockNumProduced": 224785488
+        },
+        {
+            "name": "uosswedenorg",
+            "lastBlockNumProduced": 224785452
+        }
+    ],
+    "producerToLastImpliedIrb": [
+        {
+            "name": "cryptolions1",
+            "lastBlockNumProduced": 224785464
+        },
+        {
+            "name": "eosioubisoft",
+            "lastBlockNumProduced": 224785476
+        },
+        {
+            "name": "eosnationftw",
+            "lastBlockNumProduced": 224785416
+        },
+        {
+            "name": "eosriobrazil",
+            "lastBlockNumProduced": 224785452
+        },
+        {
+            "name": "ivote4eosusa",
+            "lastBlockNumProduced": 224785428
+        },
+        {
+            "name": "uoseouldotio",
+            "lastBlockNumProduced": 224785440
+        },
+        {
+            "name": "uosswedenorg",
+            "lastBlockNumProduced": 224785404
+        }
+    ],
+    "confirmCount": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        3,
+        3,
+        3,
+        3,
+        3,
+        3,
+        3,
+        3,
+        3,
+        3,
+        3,
+        3,
+        4,
+        4,
+        4
+    ],
+    "pendingSchedule": {
+        "scheduleLibNum": 146119709,
+        "scheduleHash": "AGsM1+BObSU5Qsy6ZKVw0LseKGWLAS24+YspBvloWbA=",
+        "scheduleV2": {
+            "version": 19
+        }
+    },
+    "activatedProtocolFeatures": {
+        "protocolFeatures": [
+            "DsfggBd7LAKyeNUIhhFoa0nXOZJaktm/ys1/xrdAU70=",
+            "D+GFuIMhUYZYxU8h6R14fymGnFvA3T/HgA95iDwUAw0=",
+            "GltEdlcoFG1xuRadzlKjHV+sIUO2GwCLfKkyj92LrEU=",
+            "GpmlnYfgbgnsWwKKnLt3SbSlrYgZAENl0C3EN5qLckE=",
+            "JlL1+WAGKUEJs90LveY2k/VTJK9FK3me4TeoGpBe7SU=",
+            "KZ3LavaSMkuJmznxbVpTCjMGKATkHwncl+nxVrRHZwc=",
+            "SpDADVVFTcWwWQVcohNXnG6oVpZ3EqVgF0h4hqTUzA8=",
+            "TnvzSNoAqUVImypoF0nrVvXeALkAAU4Tfdrjn0j2nWc=",
+            "T8qL2Cu9GB5xTig/g+G0XZXKWvQPuJrTl3tlPESPeMI=",
+            "aNyqNMBRfRlmbmszrdZzUdjF9p6ZnKHjeTG8QQopdCg=",
+            "hhD9I0EwDu2GzgKTqCX+51OHZNeQlH85Frjk0ANrxMQ=",
+            "i6Uv56OVbFzTplajF0uTHTuyq7RVeL78WfKD7NgWpAU=",
+            "rZ49j2UGh3Cf1o9LkLQffYJaNlsCwjpjbO+IrCrADEM=",
+            "rqJFf5Ud6QoTLRowexOsEnXI/CSQ0nQ53UVxU9wDr48=",
+            "sLrd2WfnkQuQVpYiShE0yoMsUcth2RpqIiZSqCcVxj8=",
+            "tUHVRFIr5UqAt+N9TvxkCLdTpxQ7oQ8XDlYCpPq4wbo=",
+            "tnweAOC5Pppk0GviuW23tvSufzPvZ1bV8sL+taeCqEM=",
+            "y3nUSfgZS/a0A+QP2jGaHi+dKyEI97bLmBZi5jk+1rk=",
+            "4PtksQhcxVOJcBWNBaAJwk4nb7lOGgv2pSi0j7xP9SY=",
+            "70MRLGVDuI2yKDouB3J4wxWuLIRxmosl8lzIhWX76pk=",
+            "8K9W0sWkjWCkpbXJA+37fbOnNqlO1YnQt5ffM/+dPh0=",
+            "/Si5iGxEafNAYqQZIy9NW4AH15C4HMxtZ1/slB59gLs="
+        ]
+    },
+    "rlimitOps": [
+        {
+            "operation": "OPERATION_UPDATE",
+            "state": {
+                "averageBlockNetUsage": {
+                    "lastOrdinal": 224785514,
+                    "valueEx": "24481880",
+                    "consumed": "33"
+                },
+                "averageBlockCpuUsage": {
+                    "lastOrdinal": 224785514,
+                    "valueEx": "7263980",
+                    "consumed": "9"
+                },
+                "pendingNetUsage": "696",
+                "pendingCpuUsage": "262",
+                "totalNetWeight": "11663000000",
+                "totalCpuWeight": "11663000000",
+                "totalRamBytes": "6888821482",
+                "virtualNetLimit": "1048576",
+                "virtualCpuLimit": "400000"
+            }
+        },
+        {
+            "operation": "OPERATION_UPDATE",
+            "state": {
+                "averageBlockNetUsage": {
+                    "lastOrdinal": 224785515,
+                    "valueEx": "30077864",
+                    "consumed": "721"
+                },
+                "averageBlockCpuUsage": {
+                    "lastOrdinal": 224785515,
+                    "valueEx": "9386780",
+                    "consumed": "270"
+                },
+                "totalNetWeight": "11663000000",
+                "totalCpuWeight": "11663000000",
+                "totalRamBytes": "6888821482",
+                "virtualNetLimit": "1048576",
+                "virtualCpuLimit": "400000"
+            }
+        }
+    ],
+    "filteredTransactions": [
+        {
+            "id": "fb1f56096df0b076ad8429c6c3146092b9b03f290219ebe62f7b227d5f6689d3",
+            "status": "TRANSACTIONSTATUS_EXECUTED",
+            "cpuUsageMicroSeconds": 261,
+            "netUsageWords": 86,
+            "packedTransaction": {
+                "signatures": [
+                    "SIG_K1_KYFWhV8SQqv9u6jG6nnFbhkUUPrBicdjCYC81LiJFwfFX6gcYdbcwh6a78eG6pwGncU5dYdUsvTEukGLQz2DAzWTA8WMDx"
+                ],
+                "compression": 1,
+                "packedContextFreeData": "eJxjAAAAAQAB",
+                "packedTransaction": "eJwTcmxM5/gix346hAEIGBmWNZkwvzIIBbLDdW3OnmVkcJjKxlhcfAUku+KtkZEVXKBv5xsmIH2Are2pGVCSI9Q/GKRIMj05tbK4JL8qMUXHyNTYVMcISBoYW5hbMAAAoDgerQ=="
+            }
+        }
+    ],
+    "unfilteredTransactionCount": 1,
+    "filteredTransactionCount": 1,
+    "filteredTransactionTraces": [
+        {
+            "id": "fb1f56096df0b076ad8429c6c3146092b9b03f290219ebe62f7b227d5f6689d3",
+            "blockNum": "224785515",
+            "index": "1",
+            "blockTime": "2025-01-10T15:46:01Z",
+            "producerBlockId": "0d65f46b04f618e62675c2d693c6a3594dca5b5f946d802f7bc44c85e86ba3ea",
+            "receipt": {
+                "status": "TRANSACTIONSTATUS_EXECUTED",
+                "cpuUsageMicroSeconds": 261,
+                "netUsageWords": 86
+            },
+            "elapsed": "1828",
+            "netUsage": "688",
+            "actionTraces": [
+                {
+                    "receiver": "eosio.token",
+                    "receipt": {
+                        "receiver": "eosio.token",
+                        "digest": "35c73e7591a00b074998de84f054c64378f6daf989bedf45d9b2c99c204e9bc3",
+                        "globalSequence": "408070916",
+                        "authSequence": [
+                            {
+                                "accountName": "ultra.camp",
+                                "sequence": "3"
+                            }
+                        ],
+                        "recvSequence": "195062",
+                        "codeSequence": "5",
+                        "abiSequence": "5"
+                    },
+                    "action": {
+                        "account": "eosio.token",
+                        "name": "transfer",
+                        "authorization": [
+                            {
+                                "actor": "ultra.camp",
+                                "permission": "active"
+                            }
+                        ],
+                        "jsonData": "{\"from\":\"ultra.camp\",\"to\":\"ultra.rgrab\",\"quantity\":\"2357.79000000 UOS\",\"memo\":\"gceystozad,2535,225303878\"}",
+                        "rawData": "AECVBgFzc9QAjrnsAnNz1MAGhuU2AAAACFVPUwAAAAAZZ2NleXN0b3phZCwyNTM1LDIyNTMwMzg3OA=="
+                    },
+                    "elapsed": "1432",
+                    "transactionId": "fb1f56096df0b076ad8429c6c3146092b9b03f290219ebe62f7b227d5f6689d3",
+                    "blockNum": "224785515",
+                    "producerBlockId": "0d65f46b04f618e62675c2d693c6a3594dca5b5f946d802f7bc44c85e86ba3ea",
+                    "blockTime": "2025-01-10T15:46:01Z",
+                    "actionOrdinal": 1,
+                    "filteringMatched": true
+                },
+                {
+                    "receiver": "ultra.camp",
+                    "receipt": {
+                        "receiver": "ultra.camp",
+                        "digest": "35c73e7591a00b074998de84f054c64378f6daf989bedf45d9b2c99c204e9bc3",
+                        "globalSequence": "408070917",
+                        "authSequence": [
+                            {
+                                "accountName": "ultra.camp",
+                                "sequence": "4"
+                            }
+                        ],
+                        "recvSequence": "2",
+                        "codeSequence": "5",
+                        "abiSequence": "5"
+                    },
+                    "action": {
+                        "account": "eosio.token",
+                        "name": "transfer",
+                        "authorization": [
+                            {
+                                "actor": "ultra.camp",
+                                "permission": "active"
+                            }
+                        ],
+                        "jsonData": "{\"from\":\"ultra.camp\",\"to\":\"ultra.rgrab\",\"quantity\":\"2357.79000000 UOS\",\"memo\":\"gceystozad,2535,225303878\"}",
+                        "rawData": "AECVBgFzc9QAjrnsAnNz1MAGhuU2AAAACFVPUwAAAAAZZ2NleXN0b3phZCwyNTM1LDIyNTMwMzg3OA=="
+                    },
+                    "elapsed": "6",
+                    "transactionId": "fb1f56096df0b076ad8429c6c3146092b9b03f290219ebe62f7b227d5f6689d3",
+                    "blockNum": "224785515",
+                    "producerBlockId": "0d65f46b04f618e62675c2d693c6a3594dca5b5f946d802f7bc44c85e86ba3ea",
+                    "blockTime": "2025-01-10T15:46:01Z",
+                    "actionOrdinal": 2,
+                    "creatorActionOrdinal": 1,
+                    "closestUnnotifiedAncestorActionOrdinal": 1,
+                    "executionIndex": 1,
+                    "filteringMatched": true
+                },
+                {
+                    "receiver": "ultra.rgrab",
+                    "receipt": {
+                        "receiver": "ultra.rgrab",
+                        "digest": "35c73e7591a00b074998de84f054c64378f6daf989bedf45d9b2c99c204e9bc3",
+                        "globalSequence": "408070918",
+                        "authSequence": [
+                            {
+                                "accountName": "ultra.camp",
+                                "sequence": "5"
+                            }
+                        ],
+                        "recvSequence": "8",
+                        "codeSequence": "5",
+                        "abiSequence": "5"
+                    },
+                    "action": {
+                        "account": "eosio.token",
+                        "name": "transfer",
+                        "authorization": [
+                            {
+                                "actor": "ultra.camp",
+                                "permission": "active"
+                            }
+                        ],
+                        "jsonData": "{\"from\":\"ultra.camp\",\"to\":\"ultra.rgrab\",\"quantity\":\"2357.79000000 UOS\",\"memo\":\"gceystozad,2535,225303878\"}",
+                        "rawData": "AECVBgFzc9QAjrnsAnNz1MAGhuU2AAAACFVPUwAAAAAZZ2NleXN0b3phZCwyNTM1LDIyNTMwMzg3OA=="
+                    },
+                    "elapsed": "224",
+                    "transactionId": "fb1f56096df0b076ad8429c6c3146092b9b03f290219ebe62f7b227d5f6689d3",
+                    "blockNum": "224785515",
+                    "producerBlockId": "0d65f46b04f618e62675c2d693c6a3594dca5b5f946d802f7bc44c85e86ba3ea",
+                    "blockTime": "2025-01-10T15:46:01Z",
+                    "actionOrdinal": 3,
+                    "creatorActionOrdinal": 1,
+                    "closestUnnotifiedAncestorActionOrdinal": 1,
+                    "executionIndex": 2,
+                    "filteringMatched": true
+                }
+            ],
+            "dbOps": [
+                {
+                    "operation": "OPERATION_UPDATE",
+                    "code": "eosio.token",
+                    "scope": "ultra.camp",
+                    "tableName": "accounts",
+                    "primaryKey": "........ehbp5",
+                    "oldPayer": "eosio.token",
+                    "newPayer": "eosio.token",
+                    "oldData": "AMAlyy4CAAAIVU9TAAAAAA==",
+                    "newData": "QLmf5fcBAAAIVU9TAAAAAA=="
+                },
+                {
+                    "operation": "OPERATION_UPDATE",
+                    "code": "eosio.token",
+                    "scope": "ultra.rgrab",
+                    "tableName": "accounts",
+                    "primaryKey": "........ehbp5",
+                    "oldPayer": "eosio.token",
+                    "newPayer": "eosio.token",
+                    "oldData": "AAAAAAAAAAAIVU9TAAAAAA==",
+                    "newData": "wAaG5TYAAAAIVU9TAAAAAA=="
+                },
+                {
+                    "operation": "OPERATION_UPDATE",
+                    "actionIndex": 2,
+                    "code": "ultra.rgrab",
+                    "scope": "ultra.rgrab",
+                    "tableName": "campaign",
+                    "primaryKey": "gceystozad",
+                    "oldPayer": "ultra.rgrab",
+                    "newPayer": "ultra.rgrab",
+                    "oldData": "AEAyn2bsFWIAAAAAAAAAAAhVT1MAAAAA5wkAAAAAAAAAQJUGAXNz1AAAAAA=",
+                    "newData": "AEAyn2bsFWLABoblNgAAAAhVT1MAAAAA5wkAAAAAAAAAQJUGAXNz1EbdbQ0="
+                }
+            ],
+            "rlimitOps": [
+                {
+                    "operation": "OPERATION_UPDATE",
+                    "accountUsage": {
+                        "owner": "ultra.camp",
+                        "netUsage": {
+                            "lastOrdinal": 1579678322,
+                            "valueEx": "34605",
+                            "consumed": "689"
+                        },
+                        "cpuUsage": {
+                            "lastOrdinal": 1579678322,
+                            "valueEx": "13185",
+                            "consumed": "262"
+                        },
+                        "ramUsage": "30214"
+                    }
+                }
+            ],
+            "creationTree": [
+                {
+                    "creatorActionIndex": -1
+                },
+                {
+                    "executionActionIndex": 1
+                },
+                {
+                    "executionActionIndex": 2
+                }
+            ]
+        }
+    ],
+    "unfilteredTransactionTraceCount": 2,
+    "filteredTransactionTraceCount": 1,
+    "unfilteredExecutedInputActionCount": 2,
+    "filteredExecutedInputActionCount": 1,
+    "unfilteredExecutedTotalActionCount": 4,
+    "filteredExecutedTotalActionCount": 3,
+    "validBlockSigningAuthorityV2": {
+        "v0": {
+            "threshold": 1,
+            "keys": [
+                {
+                    "publicKey": "EOS7rzTcsDq45H1o8BGVPQQoGCnWrsNrmqgUfLDmefVho4nvuM7Ka",
+                    "weight": 1
+                }
+            ]
+        }
+    },
+    "activeScheduleV2": {
+        "version": 19,
+        "producers": [
+            {
+                "accountName": "eosriobrazil",
+                "blockSigningAuthority": {
+                    "v0": {
+                        "threshold": 1,
+                        "keys": [
+                            {
+                                "publicKey": "EOS6e6CFvEtcCGTbj8YyVwmNRiQ7FRFjbuKfTSaJXvciaVYdW2W6B",
+                                "weight": 1
+                            }
+                        ]
+                    }
+                }
+            },
+            {
+                "accountName": "cryptolions1",
+                "blockSigningAuthority": {
+                    "v0": {
+                        "threshold": 1,
+                        "keys": [
+                            {
+                                "publicKey": "EOS8KamrzrcGzKF7N5T8y44QwEwubHyJ7W6oeNehnmXTsEjQR8KYd",
+                                "weight": 1
+                            }
+                        ]
+                    }
+                }
+            },
+            {
+                "accountName": "eosioubisoft",
+                "blockSigningAuthority": {
+                    "v0": {
+                        "threshold": 1,
+                        "keys": [
+                            {
+                                "publicKey": "EOS7rzTcsDq45H1o8BGVPQQoGCnWrsNrmqgUfLDmefVho4nvuM7Ka",
+                                "weight": 1
+                            }
+                        ]
+                    }
+                }
+            },
+            {
+                "accountName": "uosswedenorg",
+                "blockSigningAuthority": {
+                    "v0": {
+                        "threshold": 1,
+                        "keys": [
+                            {
+                                "publicKey": "EOS7DjFq5FA3pyzUzXqLhA7qBSkmpZ57M6uYULTRA9E2Y4YRt7oWF",
+                                "weight": 1
+                            }
+                        ]
+                    }
+                }
+            },
+            {
+                "accountName": "eosnationftw",
+                "blockSigningAuthority": {
+                    "v0": {
+                        "threshold": 1,
+                        "keys": [
+                            {
+                                "publicKey": "EOS5uMMtMvBp4pPEBiUsfdBR9LVnJnzUonGFvQtwnh1eoXzZZKN8U",
+                                "weight": 1
+                            }
+                        ]
+                    }
+                }
+            },
+            {
+                "accountName": "ivote4eosusa",
+                "blockSigningAuthority": {
+                    "v0": {
+                        "threshold": 1,
+                        "keys": [
+                            {
+                                "publicKey": "EOS5gKJLRWxMgLWDsvKu7YaTweoQpqin5SSzJ4mDuaXnQ6tZb1F31",
+                                "weight": 1
+                            }
+                        ]
+                    }
+                }
+            },
+            {
+                "accountName": "uoseouldotio",
+                "blockSigningAuthority": {
+                    "v0": {
+                        "threshold": 1,
+                        "keys": [
+                            {
+                                "publicKey": "EOS57zSgkDgcj1XeMFqZes5Tz6fJNnCug8KYADJ1EY2Z9YGjs7Psx",
+                                "weight": 1
+                            }
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+    "filteringApplied": true,
+    "filteringIncludeFilterExpr": "account==\"eosio.token\" || (action==\"setabi\" \u0026\u0026 account==\"eosio\" \u0026\u0026 data.account==\"eosio.token\")"
+}

--- a/transaction.go
+++ b/transaction.go
@@ -313,15 +313,14 @@ type transactionGenerator struct {
 }
 
 func (t transactionGenerator) Apply(genContext TransactionContext) ([]*kafka.Message, error) {
-
 	transactionMap := newTransactionMap(genContext.transaction)
-	codec, err := t.abiCodec.GetCodec(transactionNotification, 0)
+	codec, err := t.abiCodec.GetCodec(transactionSchema.AsCodecId(), 0)
 	if err != nil {
 		return nil, fmt.Errorf("transactionGenerator.Apply() fail to get codec for %s: %w", transactionNotification, err)
 	}
 	value, err := codec.Marshal(nil, transactionMap)
 	if err != nil {
-		return nil, fmt.Errorf("transactionGenerator.Apply() fail to marshal %s: %w", dkafkaCheckpoint, err)
+		return nil, fmt.Errorf("transactionGenerator.Apply() fail to marshal %s: %w", transactionNotification, err)
 	}
 	transactionIdBytes := []byte(genContext.transaction.Id)
 	headers := append(t.headers,

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -270,7 +270,7 @@ func Test_transactionGenerator_Apply(t *testing.T) {
 		t.Run(tt.name, func(t1 *testing.T) {
 			abiCodec := NewStreamedAbiCodecWithTransaction(&DfuseAbiRepository{},
 				nil, srclient.CreateMockSchemaRegistryClient("mock://bench-adapter"), "", "mock://bench-adapter")
-			codec, err := abiCodec.GetCodec(transactionNotification, 0)
+			codec, err := abiCodec.GetCodec(transactionSchema.AsCodecId(), 0)
 			if err != nil {
 				t.Fatalf("cannot load codec for %s", transactionNotification)
 			}


### PR DESCRIPTION
Some table changes were missing because we were listening/filtering the actions when running cdc tables.
This evolution requires the support of multiple smart-contracts simultaneously and not only the targeted smart-contract.
To prevent too much modifications in the behavior the filter was only modified for the cdc tables and not the cdc actions.