### PR TITLE
[UOD-2378] fix duplicate declaration of Asset when used with ExtendedAsset

### DIFF
--- a/codec_test.go
+++ b/codec_test.go
@@ -693,7 +693,7 @@ func TestMoreAsset(t *testing.T) {
 func TestAvroCodecExtendedAsset(t *testing.T) {
 	var nullableExtendedAsset = newRecordFQN("dkafka.test", "ExtendedAccount",
 		[]FieldSchema{
-			NewOptionalField("balance", extendedAssetSchema),
+			NewOptionalField("balance", extendedAssetSchemaGenerator(map[string]string{})),
 		})
 
 	jsonSchema, err := json.Marshal(nullableExtendedAsset)


### PR DESCRIPTION
Sometimes we have a combination of fields that are `asset` and others `extended_asset`, which leads to a duplication of the Asset record declaration.